### PR TITLE
[Feature] Add lazy server support

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -262,11 +262,14 @@ type ServerConfig struct {
 	DebugAutopause          *bool   `json:"debugAutopause" env:"DEBUG_AUTOPAUSE" default:"false" desc:"Enable autopause debugging output" input:"checkbox" label:"Debug Auto-Pause"`
 
 	// Auto-Stop
-	EnableAutostop      *bool `json:"enableAutostop" env:"ENABLE_AUTOSTOP" default:"false" desc:"Enable autostop functionality" input:"checkbox" label:"Enable Auto-Stop"`
-	AutostopTimeoutEst  *int  `json:"autostopTimeoutEst" env:"AUTOSTOP_TIMEOUT_EST" default:"3600" desc:"Time between last disconnect and stopping (seconds)" input:"number" label:"Auto-Stop Timeout (Established)"`
-	AutostopTimeoutInit *int  `json:"autostopTimeoutInit" env:"AUTOSTOP_TIMEOUT_INIT" default:"1800" desc:"Time between server start and stopping if no client connects (seconds)" input:"number" label:"Auto-Stop Timeout (Initial)"`
-	AutostopPeriod      *int  `json:"autostopPeriod" env:"AUTOSTOP_PERIOD" default:"10" desc:"Period of the autostop state machine (seconds)" input:"number" label:"Auto-Stop Period"`
-	DebugAutostop       *bool `json:"debugAutostop" env:"DEBUG_AUTOSTOP" default:"false" desc:"Enable autostop debugging output" input:"checkbox" label:"Debug Auto-Stop"`
+	EnableAutostop            *bool   `json:"enableAutostop" env:"ENABLE_AUTOSTOP" default:"false" desc:"Enable autostop functionality" input:"checkbox" label:"Enable Auto-Stop"`
+	AutostopTimeoutEst        *int    `json:"autostopTimeoutEst" env:"AUTOSTOP_TIMEOUT_EST" default:"3600" desc:"Time between last disconnect and stopping (seconds)" input:"number" label:"Auto-Stop Timeout (Established)"`
+	AutostopTimeoutInit       *int    `json:"autostopTimeoutInit" env:"AUTOSTOP_TIMEOUT_INIT" default:"1800" desc:"Time between server start and stopping if no client connects (seconds)" input:"number" label:"Auto-Stop Timeout (Initial)"`
+	AutostopPeriod            *int    `json:"autostopPeriod" env:"AUTOSTOP_PERIOD" default:"10" desc:"Period of the autostop state machine (seconds)" input:"number" label:"Auto-Stop Period"`
+	EnableLazyServer          *bool   `json:"enableLazyServer" default:"false" desc:"Extends Auto-Stop with lazy-server behavior. While stopped, the proxy keeps the server visible in Minecraft's server list without running the Minecraft server. Connecting starts the server again. Requires Proxy System in Settings → Routing and a Custom Hostname in Server → Routing." input:"checkbox" label:"Enable Lazy Server"`
+	LazyServerMOTD            *string `json:"lazyServerMotd" default:"☾ Server is sleeping — connect to wake it up" desc:"Message shown in Minecraft's server list while the server is stopped." input:"text" label:"Lazy Server List Message"`
+	LazyServerStartingMessage *string `json:"lazyServerStartingMessage" default:"⌛ Server is starting — retry in a few seconds" desc:"Disconnect message shown when a player connection starts the stopped server." input:"text" label:"Lazy Server Starting Message"`
+	DebugAutostop             *bool   `json:"debugAutostop" env:"DEBUG_AUTOSTOP" default:"false" desc:"Enable autostop debugging output" input:"checkbox" label:"Debug Auto-Stop"`
 
 	// Forge Configuration
 	ForgeVersion      *string `json:"forgeVersion" env:"FORGE_VERSION" default:"" desc:"Specific Forge version to install" input:"text" label:"Forge Version"`

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -378,6 +378,7 @@ func (c *Client) CreateContainer(ctx context.Context, server *models.Server, ser
 
 	// Determine container port - proxy servers always use default port internally
 	useProxy := server.ProxyHostname != ""
+	lazyServer := useProxy && serverConfig.EnableAutostop != nil && *serverConfig.EnableAutostop && serverConfig.EnableLazyServer != nil && *serverConfig.EnableLazyServer
 	containerPort := server.Port
 	if useProxy {
 		containerPort = DefaultMinecraftPort
@@ -482,6 +483,12 @@ func (c *Client) CreateContainer(ctx context.Context, server *models.Server, ser
 
 	// Apply docker overrides
 	ApplyOverrides(server.DockerOverrides, config, hostConfig)
+
+	// Lazy servers rely on auto-stop leaving the container stopped until the
+	// proxy receives a player login and explicitly starts it again.
+	if lazyServer {
+		hostConfig.RestartPolicy = container.RestartPolicy{Name: "no"}
+	}
 
 	// Network configuration
 	networkConfig := &network.NetworkingConfig{}

--- a/internal/module/hooks.go
+++ b/internal/module/hooks.go
@@ -38,6 +38,16 @@ func (m *Manager) autoStartModules(ctx context.Context, serverID string) {
 			go func(mod *storage.Module) {
 				// Small delay to let the server settle before starting modules
 				time.Sleep(2 * time.Second)
+
+				// Geyser remains reachable while a lazy parent server sleeps, so a
+				// wake event must not try to start its running container again.
+				if mod.TemplateID == "builtin-geyser" {
+					status, err := m.GetModuleStatus(context.Background(), mod.ID)
+					if err == nil && (status == storage.ModuleStatusRunning || status == storage.ModuleStatusStarting) {
+						return
+					}
+				}
+
 				if err := m.StartModule(context.Background(), mod.ID); err != nil {
 					m.logger.Error("Failed to start module %s on server start: %v", mod.Name, err)
 				} else {

--- a/internal/proxy/manager.go
+++ b/internal/proxy/manager.go
@@ -509,6 +509,10 @@ func (m *Manager) AddModuleRoute(module *db.Module, server *db.Server) error {
 		if err := m.addPortRouteUnlocked(routeID, server.ProxyHostname, containerIP,
 			int(port.HostPort), int(port.ContainerPort), protocol, module.Name, port.Name); err != nil {
 			m.logger.Error("Failed to add port route for %s: %v", port.Name, err)
+		} else if module.TemplateID == "builtin-geyser" && protocol == "udp" {
+			if udpProxy, ok := m.proxies[int(port.HostPort)].(*UDPProxy); ok {
+				udpProxy.setLazyWakeHandler(server.ID, m.isLazyServer, m.wakeServer)
+			}
 		}
 	}
 

--- a/internal/proxy/manager.go
+++ b/internal/proxy/manager.go
@@ -20,6 +20,8 @@ type Manager struct {
 	config      *config.ProxyConfig
 	logger      *logger.Logger
 	mu          sync.Mutex
+	wakeLocks   map[string]*sync.Mutex
+	wakeHandler func(context.Context, string) error
 	networkName string
 }
 
@@ -30,6 +32,7 @@ func NewManager(store *db.Store, cfg *config.Config, logger *logger.Logger) *Man
 		store:       store,
 		config:      &cfg.Proxy,
 		logger:      logger,
+		wakeLocks:   make(map[string]*sync.Mutex),
 		networkName: cfg.Docker.NetworkName,
 	}
 }
@@ -63,8 +66,10 @@ func (m *Manager) Start() error {
 
 		listenAddr := fmt.Sprintf(":%d", listener.Port)
 		proxy := NewMinecraftProxy(&Config{
-			ListenAddr: listenAddr,
-			Logger:     m.logger,
+			ListenAddr:          listenAddr,
+			Logger:              m.logger,
+			WakeServer:          m.wakeServer,
+			GetLazyServerConfig: m.getLazyServerConfig,
 		})
 
 		m.proxies[listener.Port] = proxy
@@ -97,6 +102,14 @@ func (m *Manager) Start() error {
 			proxy, ok := m.proxies[listener.Port]
 			if !ok {
 				m.logger.Error("No proxy instance for port %d", listener.Port)
+				continue
+			}
+
+			// Lazy routes stay registered without a backend while stopped so the
+			// proxy can answer status requests and wake the server on login.
+			if server.Status == db.StatusStopped && m.isLazyServer(server.ID) {
+				proxy.AddRoute(server.ID, server.ProxyHostname, "", 25565)
+				m.logger.Info("Added sleeping proxy route for lazy server %s on listener port %d", server.Name, listener.Port)
 				continue
 			}
 
@@ -206,8 +219,18 @@ func (m *Manager) UpdateServerRoute(server *db.Server) error {
 		}
 		m.logger.Info("Updated route for server %s on port %d", server.Name, listener.Port)
 	} else if server.Status == db.StatusStopped || server.Status == db.StatusStopping {
-		// Remove route if server is stopped or stopping
-		proxy.RemoveRoute(hostname)
+		if server.Status == db.StatusStopped && m.isLazyServer(server.ID) {
+			routes := proxy.GetRoutes()
+			if _, exists := routes[hostname]; exists {
+				proxy.UpdateRoute(hostname, "", 25565)
+			} else {
+				proxy.AddRoute(server.ID, hostname, "", 25565)
+			}
+			m.logger.Info("Kept sleeping proxy route for lazy server %s on port %d", server.Name, listener.Port)
+		} else {
+			// Remove route if server is stopped or stopping
+			proxy.RemoveRoute(hostname)
+		}
 	}
 
 	return nil
@@ -310,6 +333,67 @@ func (m *Manager) IsRunning() bool {
 	return false
 }
 
+// SetWakeHandler registers the server lifecycle operation used for lazy wake-ups.
+func (m *Manager) SetWakeHandler(handler func(context.Context, string) error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.wakeHandler = handler
+}
+
+func (m *Manager) getWakeLock(serverID string) *sync.Mutex {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	lock, ok := m.wakeLocks[serverID]
+	if !ok {
+		lock = &sync.Mutex{}
+		m.wakeLocks[serverID] = lock
+	}
+
+	return lock
+}
+
+func (m *Manager) isLazyServer(serverID string) bool {
+	return m.getLazyServerConfig(context.Background(), serverID).Enabled
+}
+
+func (m *Manager) getLazyServerConfig(ctx context.Context, serverID string) LazyServerConfig {
+	serverConfig, err := m.store.GetServerConfig(ctx, serverID)
+	if err != nil {
+		return LazyServerConfig{}
+	}
+
+	lazyConfig := LazyServerConfig{
+		Enabled: serverConfig.EnableAutostop != nil && *serverConfig.EnableAutostop && serverConfig.EnableLazyServer != nil && *serverConfig.EnableLazyServer,
+	}
+	if serverConfig.LazyServerMOTD != nil {
+		lazyConfig.MOTD = *serverConfig.LazyServerMOTD
+	}
+	if serverConfig.LazyServerStartingMessage != nil {
+		lazyConfig.StartingMessage = *serverConfig.LazyServerStartingMessage
+	}
+	return lazyConfig
+}
+
+func (m *Manager) wakeServer(ctx context.Context, serverID string) error {
+	wakeLock := m.getWakeLock(serverID)
+	wakeLock.Lock()
+	defer wakeLock.Unlock()
+
+	if !m.isLazyServer(serverID) {
+		return fmt.Errorf("server is not configured as lazy")
+	}
+
+	m.mu.Lock()
+	wakeHandler := m.wakeHandler
+	m.mu.Unlock()
+	if wakeHandler == nil {
+		return fmt.Errorf("server wake handler is not configured")
+	}
+
+	return wakeHandler(ctx, serverID)
+}
+
 // AddListener creates and starts a proxy instance for a new listener
 func (m *Manager) AddListener(listener *db.ProxyListener) error {
 	m.mu.Lock()
@@ -327,8 +411,10 @@ func (m *Manager) AddListener(listener *db.ProxyListener) error {
 	// Create new proxy instance
 	listenAddr := fmt.Sprintf(":%d", listener.Port)
 	proxy := NewMinecraftProxy(&Config{
-		ListenAddr: listenAddr,
-		Logger:     m.logger,
+		ListenAddr:          listenAddr,
+		Logger:              m.logger,
+		WakeServer:          m.wakeServer,
+		GetLazyServerConfig: m.getLazyServerConfig,
 	})
 
 	// Start the proxy

--- a/internal/proxy/minecraft.go
+++ b/internal/proxy/minecraft.go
@@ -1,7 +1,9 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -14,26 +16,30 @@ import (
 
 // MinecraftProxy handles Minecraft protocol proxying with handshake parsing for hostname-based routing
 type MinecraftProxy struct {
-	listener     net.Listener
-	routes       map[string]*Route
-	routesMutex  sync.RWMutex
-	logger       *logger.Logger
-	listenAddr   string
-	running      bool
-	runningMutex sync.RWMutex
-	ctx          context.Context
-	cancel       context.CancelFunc
+	listener            net.Listener
+	routes              map[string]*Route
+	routesMutex         sync.RWMutex
+	logger              *logger.Logger
+	listenAddr          string
+	running             bool
+	runningMutex        sync.RWMutex
+	ctx                 context.Context
+	cancel              context.CancelFunc
+	wakeServer          func(context.Context, string) error
+	getLazyServerConfig func(context.Context, string) LazyServerConfig
 }
 
 // NewMinecraftProxy creates a new Minecraft proxy instance
 func NewMinecraftProxy(cfg *Config) *MinecraftProxy {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &MinecraftProxy{
-		routes:     make(map[string]*Route),
-		logger:     cfg.Logger,
-		listenAddr: cfg.ListenAddr,
-		ctx:        ctx,
-		cancel:     cancel,
+		routes:              make(map[string]*Route),
+		logger:              cfg.Logger,
+		listenAddr:          cfg.ListenAddr,
+		ctx:                 ctx,
+		cancel:              cancel,
+		wakeServer:          cfg.WakeServer,
+		getLazyServerConfig: cfg.GetLazyServerConfig,
 	}
 }
 
@@ -178,9 +184,14 @@ func (p *MinecraftProxy) handleConnection(clientConn net.Conn) {
 		p.logger.Debug("Null byte(s) detected, trimmed suffix null termination: %s", hostname)
 	}
 
-	// Find the route
+	// Copy the route while holding the lock so backend updates can happen
+	// concurrently without changing this connection's routing decision.
 	p.routesMutex.RLock()
-	route, exists := p.routes[hostname]
+	routePtr, exists := p.routes[hostname]
+	var route Route
+	if exists {
+		route = *routePtr
+	}
 	p.routesMutex.RUnlock()
 
 	if !exists || !route.Active {
@@ -194,10 +205,43 @@ func (p *MinecraftProxy) handleConnection(clientConn net.Conn) {
 		return
 	}
 
+	// Sleeping lazy servers keep their route but have no backend until a login
+	// attempt wakes the container. Server list pings must not trigger a wake-up.
+	if route.BackendHost == "" {
+		lazyConfig := p.lazyServerConfig(route.ServerID)
+		if !lazyConfig.Enabled {
+			return
+		}
+
+		switch handshake.NextState {
+		case 1:
+			if err := p.serveSleepingStatus(clientConn, handshake, lazyConfig.MOTD); err != nil {
+				p.logger.Debug("Failed to serve sleeping status for %s: %v", route.ServerID, err)
+			}
+		case 2:
+			p.wakeOnLogin(clientConn, &route, lazyConfig.StartingMessage)
+		}
+		return
+	}
+
 	// Connect to backend
 	backendAddr := net.JoinHostPort(route.BackendHost, fmt.Sprintf("%d", route.BackendPort))
 	backendConn, err := net.DialTimeout("tcp", backendAddr, 5*time.Second)
 	if err != nil {
+		lazyConfig := p.lazyServerConfig(route.ServerID)
+		if lazyConfig.Enabled {
+			p.logger.Debug("Backend %s unavailable for lazy server %s: %v", backendAddr, route.ServerID, err)
+			switch handshake.NextState {
+			case 1:
+				if err := p.serveSleepingStatus(clientConn, handshake, lazyConfig.MOTD); err != nil {
+					p.logger.Debug("Failed to serve sleeping status for %s: %v", route.ServerID, err)
+				}
+			case 2:
+				p.wakeOnLogin(clientConn, &route, lazyConfig.StartingMessage)
+			}
+			return
+		}
+
 		p.logger.Error("Failed to connect to backend %s: %v", backendAddr, err)
 		return
 	}
@@ -253,6 +297,113 @@ func (p *MinecraftProxy) handleConnection(clientConn net.Conn) {
 	}()
 
 	wg.Wait()
+}
+
+func (p *MinecraftProxy) lazyServerConfig(serverID string) LazyServerConfig {
+	lazyConfig := LazyServerConfig{}
+	if p.getLazyServerConfig != nil {
+		lazyConfig = p.getLazyServerConfig(p.ctx, serverID)
+	}
+	if lazyConfig.MOTD == "" {
+		lazyConfig.MOTD = defaultLazyServerMOTD
+	}
+	if lazyConfig.StartingMessage == "" {
+		lazyConfig.StartingMessage = defaultLazyServerStartingMessage
+	}
+	return lazyConfig
+}
+
+func (p *MinecraftProxy) wakeOnLogin(clientConn net.Conn, route *Route, startingMessage string) {
+	if p.wakeServer == nil {
+		return
+	}
+
+	if err := p.wakeServer(p.ctx, route.ServerID); err != nil {
+		p.logger.Error("Failed to wake server %s: %v", route.ServerID, err)
+		if err := writeLoginDisconnect(clientConn, "Unable to start the server. Please try again later."); err != nil {
+			p.logger.Debug("Failed to send wake error to client: %v", err)
+		}
+		return
+	}
+
+	p.logger.Info("Wake requested for lazy server %s", route.ServerID)
+	if err := writeLoginDisconnect(clientConn, startingMessage); err != nil {
+		p.logger.Debug("Failed to send starting message to client: %v", err)
+	}
+}
+
+func (p *MinecraftProxy) serveSleepingStatus(clientConn net.Conn, handshake *HandshakePacket, motd string) error {
+	packetID, payload, err := readPacket(clientConn)
+	if err != nil {
+		return err
+	}
+	if packetID != 0 || len(payload) != 0 {
+		return fmt.Errorf("expected status request packet, got id=%d payload=%d bytes", packetID, len(payload))
+	}
+
+	status := struct {
+		Version struct {
+			Name     string `json:"name"`
+			Protocol int32  `json:"protocol"`
+		} `json:"version"`
+		Players struct {
+			Max    int `json:"max"`
+			Online int `json:"online"`
+		} `json:"players"`
+		Description struct {
+			Text  string `json:"text"`
+			Color string `json:"color"`
+		} `json:"description"`
+	}{}
+	status.Version.Name = "Sleeping"
+	status.Version.Protocol = int32(handshake.ProtocolVersion)
+	status.Description.Text = motd
+	status.Description.Color = "gray"
+
+	statusJSON, err := json.Marshal(status)
+	if err != nil {
+		return fmt.Errorf("failed to encode sleeping status: %w", err)
+	}
+
+	var response bytes.Buffer
+	if err := writeString(&response, string(statusJSON)); err != nil {
+		return err
+	}
+	if err := writePacket(clientConn, 0, response.Bytes()); err != nil {
+		return fmt.Errorf("failed to write sleeping status: %w", err)
+	}
+
+	packetID, payload, err = readPacket(clientConn)
+	if err != nil {
+		return err
+	}
+	if packetID != 1 || len(payload) != 8 {
+		return fmt.Errorf("expected status ping packet, got id=%d payload=%d bytes", packetID, len(payload))
+	}
+
+	if err := writePacket(clientConn, 1, payload); err != nil {
+		return fmt.Errorf("failed to write status pong: %w", err)
+	}
+	return nil
+}
+
+func writeLoginDisconnect(w io.Writer, message string) error {
+	reason, err := json.Marshal(struct {
+		Text  string `json:"text"`
+		Color string `json:"color"`
+	}{
+		Text:  message,
+		Color: "yellow",
+	})
+	if err != nil {
+		return err
+	}
+
+	var payload bytes.Buffer
+	if err := writeString(&payload, string(reason)); err != nil {
+		return err
+	}
+	return writePacket(w, 0, payload.Bytes())
 }
 
 // GetRoutes returns a copy of all current routes

--- a/internal/proxy/protocol.go
+++ b/internal/proxy/protocol.go
@@ -58,6 +58,58 @@ func WriteVarInt(w io.Writer, value VarInt) error {
 	}
 }
 
+func readPacket(r io.Reader) (VarInt, []byte, error) {
+	length, err := ReadVarInt(r)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to read packet length: %w", err)
+	}
+	if length < 1 || length > 1<<20 {
+		return 0, nil, fmt.Errorf("invalid packet length: %d", length)
+	}
+
+	data := make([]byte, int(length))
+	if _, err := io.ReadFull(r, data); err != nil {
+		return 0, nil, fmt.Errorf("failed to read packet data: %w", err)
+	}
+
+	buf := bytes.NewReader(data)
+	packetID, err := ReadVarInt(buf)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to read packet ID: %w", err)
+	}
+
+	payload, err := io.ReadAll(buf)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to read packet payload: %w", err)
+	}
+
+	return packetID, payload, nil
+}
+
+func writePacket(w io.Writer, packetID VarInt, payload []byte) error {
+	var packet bytes.Buffer
+	if err := WriteVarInt(&packet, packetID); err != nil {
+		return err
+	}
+	if _, err := packet.Write(payload); err != nil {
+		return err
+	}
+
+	if err := WriteVarInt(w, VarInt(packet.Len())); err != nil {
+		return err
+	}
+	_, err := w.Write(packet.Bytes())
+	return err
+}
+
+func writeString(w io.Writer, value string) error {
+	if err := WriteVarInt(w, VarInt(len(value))); err != nil {
+		return err
+	}
+	_, err := io.WriteString(w, value)
+	return err
+}
+
 // Len returns the length of the VarInt when encoded
 func (v VarInt) Len() int {
 	value := int32(v)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"context"
+
 	"github.com/nickheyer/discopanel/pkg/logger"
 )
 
@@ -24,8 +26,22 @@ type Route struct {
 	Active      bool
 }
 
+const (
+	defaultLazyServerMOTD            = "☾ Server is sleeping — connect to wake it up"
+	defaultLazyServerStartingMessage = "⌛ Server is starting — retry in a few seconds"
+)
+
+// LazyServerConfig contains proxy behavior for a server configured to sleep while idle.
+type LazyServerConfig struct {
+	Enabled         bool
+	MOTD            string
+	StartingMessage string
+}
+
 // Config holds proxy configuration
 type Config struct {
-	ListenAddr string // Address to listen on (e.g., ":25565" or ":8080")
-	Logger     *logger.Logger
+	ListenAddr          string // Address to listen on (e.g., ":25565" or ":8080")
+	Logger              *logger.Logger
+	WakeServer          func(context.Context, string) error
+	GetLazyServerConfig func(context.Context, string) LazyServerConfig
 }

--- a/internal/proxy/udp.go
+++ b/internal/proxy/udp.go
@@ -10,19 +10,28 @@ import (
 	"github.com/nickheyer/discopanel/pkg/logger"
 )
 
+// RakNet sends connection traffic in bursts, so repeated packets from one join
+// must not queue duplicate server lifecycle calls.
+const lazyWakeRetryInterval = 5 * time.Second
+
 // UDPProxy handles UDP forwarding for modules like Geyser
 // Implements the Proxier interface
 type UDPProxy struct {
-	listenAddr  string
-	backendHost string
-	backendPort int
-	serverID    string
-	conn        *net.UDPConn
-	logger      *logger.Logger
-	running     bool
-	mu          sync.RWMutex
-	ctx         context.Context
-	cancel      context.CancelFunc
+	listenAddr      string
+	backendHost     string
+	backendPort     int
+	serverID        string
+	conn            *net.UDPConn
+	logger          *logger.Logger
+	running         bool
+	mu              sync.RWMutex
+	ctx             context.Context
+	cancel          context.CancelFunc
+	lazyServerID    string
+	isLazyServer    func(string) bool
+	wakeServer      func(context.Context, string) error
+	wakeInFlight    bool
+	lastWakeAttempt time.Time
 
 	// Client session tracking - maintains backend connection per client
 	sessions   map[string]*udpSession
@@ -46,6 +55,15 @@ func NewUDPProxy(cfg *Config) *UDPProxy {
 		cancel:     cancel,
 		sessions:   make(map[string]*udpSession),
 	}
+}
+
+func (p *UDPProxy) setLazyWakeHandler(serverID string, isLazyServer func(string) bool, wakeServer func(context.Context, string) error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.lazyServerID = serverID
+	p.isLazyServer = isLazyServer
+	p.wakeServer = wakeServer
 }
 
 // Start starts the UDP proxy
@@ -180,6 +198,10 @@ func (p *UDPProxy) proxyLoop() {
 			}
 		}
 
+		// RakNet discovery is forwarded to Geyser without waking Java. Connection
+		// traffic means a Bedrock client is actively trying to join.
+		p.wakeOnBedrockConnect(buf[:n])
+
 		// Get or create session for this client
 		session, err := p.getOrCreateSession(clientAddr)
 		if err != nil {
@@ -197,6 +219,48 @@ func (p *UDPProxy) proxyLoop() {
 			p.removeSession(clientAddr.String())
 		}
 	}
+}
+
+func (p *UDPProxy) wakeOnBedrockConnect(packet []byte) {
+	if !isRakNetConnectionTraffic(packet) {
+		return
+	}
+
+	p.mu.Lock()
+	serverID := p.lazyServerID
+	isLazyServer := p.isLazyServer
+	wakeServer := p.wakeServer
+	if serverID == "" || isLazyServer == nil || wakeServer == nil || p.wakeInFlight || time.Since(p.lastWakeAttempt) < lazyWakeRetryInterval {
+		p.mu.Unlock()
+		return
+	}
+	p.wakeInFlight = true
+	p.lastWakeAttempt = time.Now()
+	p.mu.Unlock()
+
+	go func() {
+		defer func() {
+			p.mu.Lock()
+			p.wakeInFlight = false
+			p.mu.Unlock()
+		}()
+
+		if !isLazyServer(serverID) {
+			return
+		}
+		if err := wakeServer(p.ctx, serverID); err != nil {
+			p.logger.Error("Failed to wake lazy server %s from Bedrock connection: %v", serverID, err)
+		}
+	}()
+}
+
+func isRakNetConnectionTraffic(packet []byte) bool {
+	if len(packet) == 0 {
+		return false
+	}
+
+	packetID := packet[0]
+	return packetID == 0x05 || packetID == 0x07 || packetID&0xf0 == 0x80
 }
 
 // getOrCreateSession gets an existing session or creates a new one

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nickheyer/discopanel/internal/ws"
 	"github.com/nickheyer/discopanel/pkg/download"
 	"github.com/nickheyer/discopanel/pkg/logger"
+	v1 "github.com/nickheyer/discopanel/pkg/proto/discopanel/v1"
 	"github.com/nickheyer/discopanel/pkg/proto/discopanel/v1/discopanelv1connect"
 	"github.com/nickheyer/discopanel/pkg/upload"
 	web "github.com/nickheyer/discopanel/web/discopanel"
@@ -191,13 +192,41 @@ func (s *Server) setupHandler() {
 func (s *Server) registerServices(mux *http.ServeMux, opts []connect.HandlerOption) {
 	// Create service instances
 	authService := services.NewAuthService(s.store, s.authManager, s.enforcer, s.oidcHandler, s.log)
-	configService := services.NewConfigService(s.store, s.config, s.docker, s.log)
+	configService := services.NewConfigService(s.store, s.config, s.docker, s.proxyManager, s.log)
 	fileService := services.NewFileService(s.store, s.docker, s.uploadManager, s.downloadManager, s.log)
 	minecraftService := services.NewMinecraftService(s.store, s.docker, s.log)
 	modService := services.NewModService(s.store, s.docker, s.uploadManager, s.log)
 	modpackService := services.NewModpackService(s.store, s.config, s.uploadManager, s.log)
 	proxyService := services.NewProxyService(s.store, s.docker, s.proxyManager, s.config, s.logStreamer, s.log)
 	serverService := services.NewServerService(s.store, s.docker, s.sender, s.config, s.proxyManager, s.logStreamer, s.metricsCollector, s.moduleManager, s.bus, s.log)
+	// Route lazy wake-ups through ServerService so they use the same lifecycle
+	// events and container handling as a manual server start.
+	if s.proxyManager != nil {
+		s.proxyManager.SetWakeHandler(func(ctx context.Context, serverID string) error {
+			server, err := s.store.GetServer(ctx, serverID)
+			if err != nil {
+				return err
+			}
+			if server.ContainerID == "" {
+				return fmt.Errorf("server has no container")
+			}
+
+			status, err := s.docker.GetContainerStatus(ctx, server.ContainerID)
+			if err != nil {
+				return err
+			}
+
+			switch status {
+			case storage.StatusRunning, storage.StatusStarting:
+				return nil
+			case storage.StatusStopped:
+				_, err = serverService.StartServer(ctx, connect.NewRequest(&v1.StartServerRequest{Id: serverID}))
+				return err
+			default:
+				return fmt.Errorf("server cannot be woken while in %s state", status)
+			}
+		})
+	}
 	supportService := services.NewSupportService(s.store, s.docker, s.config, s.log)
 	taskService := services.NewTaskService(s.store, s.scheduler, s.log)
 	userService := services.NewUserService(s.store, s.authManager, s.log)

--- a/internal/rpc/services/config.go
+++ b/internal/rpc/services/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nickheyer/discopanel/internal/config"
 	storage "github.com/nickheyer/discopanel/internal/db"
 	"github.com/nickheyer/discopanel/internal/docker"
+	"github.com/nickheyer/discopanel/internal/proxy"
 	"github.com/nickheyer/discopanel/pkg/logger"
 	v1 "github.com/nickheyer/discopanel/pkg/proto/discopanel/v1"
 	"github.com/nickheyer/discopanel/pkg/proto/discopanel/v1/discopanelv1connect"
@@ -24,15 +25,17 @@ type ConfigService struct {
 	store  *storage.Store
 	config *config.Config
 	docker *docker.Client
+	proxy  *proxy.Manager
 	log    *logger.Logger
 }
 
 // Creates new config service
-func NewConfigService(store *storage.Store, cfg *config.Config, docker *docker.Client, log *logger.Logger) *ConfigService {
+func NewConfigService(store *storage.Store, cfg *config.Config, docker *docker.Client, proxy *proxy.Manager, log *logger.Logger) *ConfigService {
 	return &ConfigService{
 		store:  store,
 		config: cfg,
 		docker: docker,
+		proxy:  proxy,
 		log:    log,
 	}
 }
@@ -109,6 +112,14 @@ func (s *ConfigService) UpdateServerConfig(ctx context.Context, req *connect.Req
 	if server.ContainerID != "" && s.docker != nil {
 		if err := s.recreateContainer(ctx, server, config); err != nil {
 			s.log.Error("Config saved but container recreation failed: %v", err)
+		}
+	}
+
+	// A stopped server will not produce a status transition after a config save,
+	// so refresh its route explicitly to apply Lazy Server changes immediately.
+	if s.proxy != nil && server.ProxyHostname != "" && server.ContainerID != "" {
+		if err := s.proxy.UpdateServerRoute(server); err != nil {
+			s.log.Error("Config saved but proxy route update failed: %v", err)
 		}
 	}
 
@@ -492,7 +503,8 @@ func getCategoryIndex(key string) int {
 		return 9
 
 	// Auto-Stop (10)
-	case "enableAutostop", "autostopTimeoutEst", "autostopTimeoutInit", "autostopPeriod", "debugAutostop":
+	case "enableAutostop", "enableLazyServer", "lazyServerMotd", "lazyServerStartingMessage",
+		"autostopTimeoutEst", "autostopTimeoutInit", "autostopPeriod", "debugAutostop":
 		return 10
 
 	// CurseForge (11)


### PR DESCRIPTION
## Summary

Implements #53.

This adds native lazy-server support by extending DiscoPanel's existing Auto-Stop and Minecraft proxy functionality.

When Auto-Stop and Lazy Server are enabled, an idle Minecraft server can stop normally to free its resources while the DiscoPanel proxy keeps its route reachable. Server-list requests are answered by the proxy without waking the server, while an actual player connection starts the server again.

No additional proxy, sidecar, or external service is required.

## Why this approach

I looked into a few alternatives, including `itzg/mc-router`, `lazymc-docker-proxy`, and integrating `lazymc` directly.

A native implementation ended up being relatively small because DiscoPanel already provides most of the required pieces:

* Docker container lifecycle management
* Auto-Stop configuration through `itzg/minecraft-server`
* Minecraft handshake parsing
* hostname-based proxy routing

Extending the existing proxy avoids introducing another proxy/service or replacing the current routing architecture for this feature.

## Behavior

With Auto-Stop enabled but Lazy Server disabled, the existing Auto-Stop behavior is unchanged.

With both Auto-Stop and Lazy Server enabled:

* the Minecraft server stops after the configured Auto-Stop timeout
* the proxy route remains available while the server is stopped
* Minecraft server-list requests do not wake the server
* the proxy responds with a configurable server-list message while the server is stopped
* an actual player connection starts the server through DiscoPanel's existing server lifecycle
* the player receives a configurable starting message and can reconnect once startup completes

The default messages are:

```text
☾ Server is sleeping — connect to wake it up
```

```text
⌛ Server is starting — retry in a few seconds
```

## Configuration

To enable lazy-server behavior:

* enable **Auto-Stop** in the server configuration
* enable **Lazy Server** in the same Auto-Stop section
* enable the **Proxy System** under `Settings → Routing`
* configure a **Custom Hostname** under `Server → Routing`

The existing Auto-Stop timeouts control when the server shuts down.

The lazy-server messages can be customized through:

* **Lazy Server List Message** — shown in Minecraft's server list while the server is stopped
* **Lazy Server Starting Message** — shown when a connection wakes the server

## Implementation

The implementation builds on DiscoPanel's existing proxy and server lifecycle.

Lazy servers keep their proxy route available after Auto-Stop. Server-list requests are handled directly by the proxy without starting Minecraft, while login attempts use the existing `StartServer` flow.

If Auto-Stop has already stopped the backend but the route still contains its previous address, the proxy treats the unreachable backend as stopped and serves the lazy-server response instead.

Normal Auto-Stop behavior remains unchanged unless Lazy Server is explicitly enabled.

## Scope

The initial player connection is intentionally not held open while Minecraft starts.

Instead, the proxy starts the server and returns the configured starting message. The player reconnects once the Minecraft server is ready.

Holding the original login connection and forwarding it after startup would require substantially more Minecraft protocol and lifecycle handling and is intentionally outside the scope of this change.

## Verification

Tested locally with a Minecraft Java client and Docker-based DiscoPanel setup:

* lazy servers stop after the configured timeout
* server-list refreshes do not wake stopped servers
* connecting wakes the server and returns the configured starting message
* reconnecting succeeds once the Minecraft server has started
